### PR TITLE
Fixing a problem on using Rails and jQuery1.9.1

### DIFF
--- a/vendor/assets/javascripts/bootstrap-toggle-buttons.js
+++ b/vendor/assets/javascripts/bootstrap-toggle-buttons.js
@@ -56,7 +56,7 @@
 
               $div = $cb.wrap($('<div></div>')).parent();
               $div.append($spanLeft);
-              $div.append($('<label></label>').attr('for', $cb.attr('id') || ''));
+              $div.append($('<label></label>').prop('for', $cb.prop('id') || ''));
               $div.append($spanRight);
 
               if ($cb.is(':checked'))
@@ -187,9 +187,9 @@
 
                     if (moving)
                       if (parseInt($(this).parent().css('left')) < -25)
-                        $myCheckBox.attr('checked', false);
-                      else $myCheckBox.attr('checked', true);
-                    else $myCheckBox.attr("checked", !$myCheckBox.is(":checked"));
+                        $myCheckBox.prop('checked', false);
+                      else $myCheckBox.prop('checked', true);
+                    else $myCheckBox.prop("checked", !$myCheckBox.is(":checked"));
 
                     $myCheckBox.trigger('change');
                   });
@@ -204,8 +204,8 @@
                     $(this).trigger('mouseup');
 
                     if (parseInt($(this).parent().css('left')) < -25)
-                      $myCheckBox.attr('checked', false);
-                    else $myCheckBox.attr('checked', true);
+                      $myCheckBox.prop('checked', false);
+                    else $myCheckBox.prop('checked', true);
 
                     $myCheckBox.trigger('change');
                   });
@@ -226,10 +226,10 @@
         },
         toggleState: function (skipOnChange) {
           var $input = $(this).find('input:checkbox');
-          $input.attr('checked', !$input.is(':checked')).trigger('change', skipOnChange);
+          $input.prop('checked', !$input.is(':checked')).trigger('change', skipOnChange);
         },
         setState: function(value, skipOnChange) {
-          $(this).find('input:checkbox').attr('checked', value).trigger('change', skipOnChange);
+          $(this).find('input:checkbox').prop('checked', value).trigger('change', skipOnChange);
         },
         status: function () {
           return $(this).find('input:checkbox').is(':checked');


### PR DESCRIPTION
In this file, I have replaced all "attr" jquery methods to "prop", because in the recent jquery version, "attr" does no longer support the feature to change the primitive such as "checked", "selectedIndex", and so on.
FYI, here are some links so that you can refer the problems between attr vs prop in jQuery.
http://stackoverflow.com/questions/13247058/jquery-attr-vs-prop
http://stackoverflow.com/questions/5874652/prop-vs-attr
http://api.jquery.com/prop/
